### PR TITLE
Added `loadMultiple` function to allow multiple loading of CSS or JS files

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,9 +1,9 @@
 EnhanceJS is developed and maintained by Filament Group, Inc (filamentgroup.com)
-with contributions of code and ideas by the following individuals: 
+with contributions of code and ideas by the following individuals:
 
 Brandon Aaron
 Scott Jehl
 Todd Parker
 Patty Toland
 Maggie Costello Wachs
-
+Zander Martineau

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ By default though, it is set up to follow these steps:
 
 1. Define some variables and functions for loading assets and accessing information about the browser and markup
 2. Run one or more tests to see if a browser is qualified to load and render additional enhancements
-3.   
+3.
 	- A. If it's not qualified, exit early and do nothing more
 	- B. If it is qualified, proceed on to load additional assets, add classes to the document, etc.
 
@@ -55,6 +55,10 @@ We also recommend loading any non-critical JavaScript asynchronously as well, an
 
 To define URLs for files that may be requested by EnhanceJS, such as a file containing JavaScript enhancements, we like to use `meta` tags in the `head` of our page.
 
+#### Loading multiple files
+
+The `loadMultiple` function has been added to allow multiple CSS or JS files to be loaded. If, for example you had `<meta name="fullcss"  content="/path/to/full.css,/path/to/sectionFull.css">` in your `meta` tags, `loadMultiple` would be used like so: `loadMultiple( fullCSS.content, loadCSS, ',' );`.
+
 ### A fully-configured `head` setup for EnhanceJS
 
 Here's an example configuration for the head of a page. It uses SSI to detect cookies and decide whether to inline CSS or request it directly.
@@ -72,7 +76,7 @@ Here's an example configuration for the head of a page. It uses SSI to detect co
 	<style>
 		/* critical CSS styles for this template go here... */
 	</style>
-<!--#endif -->	
+<!--#endif -->
 	<script>
 		<!--#include virtual="/path/to/enhance.js" -->
 	</script>
@@ -86,6 +90,6 @@ Here's an example configuration for the head of a page. It uses SSI to detect co
 
 Enhance.js exposes an object called `window.enhance` or just `enhance`. You can place whatever enhancement-related properties and methods on this object that you might want to use elsewhere in your codebase, or, none at all.
 
-By default, we typically expose functions like `loadCSS`, `loadJS`, `getMeta`, and `cookie`, so that we can use these in other scripts in our codebase.
+By default, we typically expose functions like `loadCSS`, `loadJS`, `loadMultiple`, `getMeta`, and `cookie`, so that we can use these in other scripts in our codebase.
 
 You might choose to expose feature support information, or even user agent info if you really need that.

--- a/enhance.js
+++ b/enhance.js
@@ -78,6 +78,16 @@
 	// expose it
 	enhance.loadCSS = loadCSS;
 
+	// load multiple files using loadCSS or loadJS
+	// example usage: loadMultiple(fullCSS.content, loadCSS, ',');
+	function loadMultiple(string, fn, separator) {
+		var arr = string.split(separator)
+		for (var i = arr.length - 1; i >= 0; i--) {
+			fn(arr[i]);
+		}
+	}
+	enhance.loadMultiple = multiple; // expose it
+
 	// getMeta function: get a meta tag by name
 	// NOTE: meta tag must be in the HTML source before this script is included in order to guarantee it'll be found
 	function getMeta( metaname ){
@@ -97,7 +107,7 @@
 
 	// cookie function from https://github.com/filamentgroup/cookie/
 	function cookie( name, value, days ){
-    var expires;
+		var expires;
 		// if value is undefined, get the cookie value
 		if( value === undefined ){
 			var cookiestring = "; " + window.document.cookie;
@@ -137,7 +147,7 @@
 		*/
 	var fullCSS = getMeta( fullCSSKey );
 	if( fullCSS && !cookie( fullCSSKey ) ){
-		loadCSS( fullCSS.content );
+		loadMultiple( fullCSS.content, loadCSS, ',' );
 		// set cookie to mark this file fetched
 		cookie( fullCSSKey, "true", 7 );
 	}
@@ -163,7 +173,7 @@
 		*/
 	var fullJS = getMeta( fullJSKey );
 	if( fullJS ){
-		loadJS( fullJS.content );
+		loadMultiple( fullJS.content, loadJS, ',' );
 	}
 
 	/* Load custom fonts
@@ -174,7 +184,7 @@
 		*/
 	var fonts = getMeta( fontsKey );
 	if( fonts ){
-		loadCSS( fonts.content );
+		loadMultiple( fonts.content, loadCSS, ',' );
 	}
 
 	// expose the 'enhance' object globally. Use it to expose anything in here that's useful to other parts of your application.


### PR DESCRIPTION
I added a simple function, `loadMultiple` to allow loading of multiple files from the `meta` tags  if they are comma separated. This references issue #7 directly.
